### PR TITLE
Update discord.reclaimers.net redirect to point to landing channel

### DIFF
--- a/src/stacks/discord.ts
+++ b/src/stacks/discord.ts
@@ -18,7 +18,7 @@ export class DiscordRedirectStack extends cdk.Stack {
         return {
           statusCode: 301,
           headers: {
-            Location: "https://discord.gg/k6Q4JBp"
+            Location: "https://discord.gg/tVduNg9Ztb"
           }
         };
       };


### PR DESCRIPTION
To be fair, I've already done this through the AWS console, but here is a PR because I want to be nice about it on github.